### PR TITLE
Encoder irregular speed fix

### DIFF
--- a/src/Encoder.cpp
+++ b/src/Encoder.cpp
@@ -15,19 +15,21 @@ void Encoder::update(){
     bool rawA = !digitalRead(pinA);
     bool rawB = !digitalRead(pinB);
 
-    if(rawA != last_a){
-        if(rawB != rawA){
-            state++;
-        }else{
-            state--;
-        }
-        if(state > 1 || state < -1){
+    if(rawB != last_b){
+        state--;
+        if(state < -1){
             state = 0;
         }
     }
-    
-    last_a = rawA;
     last_b = rawB;
+
+    if(rawA != last_a){
+        state++;
+        if(state > 1){
+            state = 0;
+        }
+    }
+    last_a = rawA;
 }
 
 void Encoder::print(){


### PR DESCRIPTION
In current code, the left side can activate twice as fast as the right side.

It is like that because you only check if rawA has changed, so in order to activate the right side it firstly must go through the left pin, halving the speed of detection.

Not noticeable if you turn it slowly, but if you have it bound to a speed or radio volume in ets2 for example, you can easily feel the difference.